### PR TITLE
improve: DX, SEO, and repo hygiene

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,17 +12,17 @@
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://devutils.app/">
+    <meta property="og:url" content="https://devutils-one.vercel.app/">
     <meta property="og:title" content="DevUtils - Developer Tools for Everyday Tasks">
     <meta property="og:description" content="A collection of essential developer utilities including formatters, converters, encoders/decoders, and more. All tools work offline and are free to use.">
-    <meta property="og:image" content="https://devutils.app/preview.png">
+    <meta property="og:image" content="https://devutils-one.vercel.app/preview.png">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://devutils.app/">
+    <meta property="twitter:url" content="https://devutils-one.vercel.app/">
     <meta property="twitter:title" content="DevUtils - Developer Tools for Everyday Tasks">
     <meta property="twitter:description" content="A collection of essential developer utilities including formatters, converters, encoders/decoders, and more. All tools work offline and are free to use.">
-    <meta property="twitter:image" content="https://devutils.app/preview.png">
+    <meta property="twitter:image" content="https://devutils-one.vercel.app/preview.png">
   </head>
   <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "devutils",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -23,7 +23,6 @@
     "@types/csso": "^5.0.4",
     "@uiw/react-textarea-code-editor": "^3.0.2",
     "blueimp-md5": "^2.19.0",
-    "capture-website": "^4.2.0",
     "change-case": "^5.4.4",
     "colord": "^2.9.3",
     "cronstrue": "^2.53.0",
@@ -41,7 +40,6 @@
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.3",
     "react-router-dom": "^7.5.2",
-    "sharp": "^0.33.2",
     "sql-formatter": "^15.4.10",
     "terser": "^5.37.0",
     "ulid": "^2.3.0",
@@ -69,6 +67,8 @@
     "@types/sharp": "^0.32.0",
     "@types/uuid": "^9.0.8",
     "@vitejs/plugin-react": "^4.3.1",
+    "capture-website": "^4.2.0",
+    "sharp": "^0.33.2",
     "autoprefixer": "^10.4.18",
     "babel-jest": "^29.7.0",
     "eslint": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -350,8 +350,6 @@ function Layout({ tools: defaultTools }: { tools: Tool[] }) {
   };
 
   const handleStartTour = () => {
-    console.log('Start tutorial button clicked');
-    console.log('Current tour state:', state);
     startTour();
   };
 
@@ -488,7 +486,14 @@ function Layout({ tools: defaultTools }: { tools: Tool[] }) {
         {isSidebarExpanded && (
           <div className="p-4 border-t border-gray-200 text-xs text-gray-500">
             <div className="flex items-center justify-center">
-              Last updated: Jul 23, 2025
+              <a
+                href="https://github.com/nadimtuhin/devutils"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-blue-600 no-underline"
+              >
+                v{__APP_VERSION__}
+              </a>
             </div>
           </div>
         )}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,15 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { readFileSync } from 'fs';
+
+const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
+  },
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
## Changes

### Bug fixes
- Remove `console.log` debug statements from production code (App.tsx)
- Fix OG/Twitter meta URLs pointing to wrong domain (`devutils.app` → `devutils-one.vercel.app`)

### DX improvements
- Replace hardcoded `Last updated: Jul 23, 2025` in sidebar footer with dynamic `v{__APP_VERSION__}` linked to GitHub releases
- Bump package version `0.0.0` → `1.0.0`
- Move `capture-website` and `sharp` from `dependencies` → `devDependencies` (they're only used by screenshot scripts, not the app)

### Repo improvements
- Add `CONTRIBUTING.md` with dev setup, tool conventions, and PR process
- Add 10 GitHub topics for search discoverability (`developer-tools`, `devtools`, `react`, `typescript`, `privacy`, `offline`, `browser-tools`, `utilities`, `vite`, `tailwindcss`)
- Homepage URL corrected in GitHub repo settings